### PR TITLE
BugFix: Fix display issue for names without middle names

### DIFF
--- a/fe/src/pages/Employee.tsx
+++ b/fe/src/pages/Employee.tsx
@@ -174,7 +174,9 @@ const Employee = () => {
                       {item.employee_cd}
                     </th>
                     <td className="text-sm px-6 py-4 capitalize">
-                      {`${item.first_name} ${item.middle_name} ${item.sur_name}`.toLowerCase()}
+                      {`${item.first_name} ${
+                        item.middle_name ? item.middle_name : ""
+                      } ${item.sur_name}`.toLowerCase()}
                     </td>
                     <td className="text-sm px-6 py-4">{item.email}</td>
                     <td className="px-6 py-4">


### PR DESCRIPTION
Fix issue where names without middle names were displayed incorrectly in employee list. The bug caused names to appear as "Jennifer null Aninston" instead of "Jennifer Aninston" when the middle name was absent.